### PR TITLE
Add query customers by name (#21)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -128,10 +128,13 @@ def list_pets():
     """Returns all of the Customers"""
     app.logger.info("Request for the customer list")
 
-    customers = Customer.all()
-
-    app.logger.info("Find all")
-    # pets = Pet.all()
+    name = request.args.get("name")
+    if name:
+        app.logger.info("Find by name: %s", name)
+        customers = Customer.find_by_name(name)
+    else:
+        app.logger.info("Find all")
+        customers = Customer.all()
 
     results = [customer.serialize() for customer in customers]
     app.logger.info("Returning %d customers", len(results))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -221,3 +221,43 @@ class TestYourResourceService(TestCase):
         # PATCH is not defined on /customers
         response = self.client.patch(BASE_URL, json={})
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_query_customers_by_name(self):
+        """It should return only customers matching the queried name"""
+        customers = CustomerFactory.create_batch(5)
+        for customer in customers:
+            customer.create()
+        target_name = customers[0].name
+        customers[1].name = target_name
+        customers[1].update()
+
+        response = self.client.get(BASE_URL, query_string={"name": target_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), 2)
+        for customer in data:
+            self.assertEqual(customer["name"], target_name)
+
+    def test_query_customers_by_name_no_match(self):
+        """It should return an empty list when no customers match the queried name"""
+        customers = CustomerFactory.create_batch(3)
+        for customer in customers:
+            customer.create()
+
+        response = self.client.get(
+            BASE_URL, query_string={"name": "NonExistentName12345"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data, [])
+
+    def test_list_customers_without_query(self):
+        """It should return all customers when no query string is provided"""
+        customers = CustomerFactory.create_batch(4)
+        for customer in customers:
+            customer.create()
+
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), 4)


### PR DESCRIPTION
## Changes:
- Enhanced the `GET /customers` endpoint to accept an optional `?name=<value>` query parameter
- When `name` is provided, returns only matching customers using the existing `find_by_name()` model method
- When no query string is given, returns all customers as before
- Returns empty list `[]` (not 404) when no customers match
- Added unit tests for filtered, unfiltered, and no-match cases
- Maintains 95%+ code coverage