### PR TITLE
Add status and test

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -28,6 +28,7 @@ class Customer(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(63), nullable=False)
     address = db.Column(db.String(255), nullable=False)
+    status = db.Column(db.String(63), nullable=False, default="active")
 
     def __repr__(self):
         return f"<Customer {self.name} id=[{self.id}]>"
@@ -75,6 +76,7 @@ class Customer(db.Model):
             "id": self.id,
             "name": self.name,
             "address": self.address,
+            "status": self.status,
         }
 
     def deserialize(self, data):
@@ -87,6 +89,7 @@ class Customer(db.Model):
         try:
             self.name = data["name"]
             self.address = data["address"]
+            self.status = data.get("status", "active")
         except AttributeError as error:
             raise DataValidationError("Invalid attribute: " + error.args[0]) from error
         except KeyError as error:

--- a/service/routes.py
+++ b/service/routes.py
@@ -142,6 +142,32 @@ def list_pets():
 
 
 ######################################################################
+# SUSPEND A CUSTOMER
+######################################################################
+@app.route("/customers/<int:customer_id>/suspend", methods=["PUT"])
+def suspend_customer(customer_id):
+    """
+    Suspend a Customer
+
+    This endpoint will suspend a Customer based on the id specified in the path
+    """
+    app.logger.info("Request to suspend customer with id: %s", customer_id)
+
+    customer = Customer.find(customer_id)
+    if not customer:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Customer with id '{customer_id}' was not found.",
+        )
+
+    customer.status = "suspended"
+    customer.update()
+
+    app.logger.info("Customer with ID: %d suspended.", customer.id)
+    return jsonify(customer.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 # UTILITY FUNCTIONS
 ######################################################################
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,3 +17,4 @@ class CustomerFactory(factory.Factory):
     id = factory.Sequence(lambda n: n)
     name = factory.Faker("name")
     address = factory.Faker("address")
+    status = "active"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -261,3 +261,32 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.get_json()
         self.assertEqual(len(data), 4)
+
+    def test_suspend_a_customer(self):
+        """It should Suspend an existing Customer"""
+        test_customer = CustomerFactory()
+        test_customer.create()
+
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/suspend")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "suspended")
+
+    def test_suspend_nonexistent_customer(self):
+        """It should return 404 when suspending a Customer that does not exist"""
+        response = self.client.put(f"{BASE_URL}/0/suspend")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("was not found", data["message"])
+
+    def test_suspended_status_persists(self):
+        """It should persist the suspended status after a GET"""
+        test_customer = CustomerFactory()
+        test_customer.create()
+
+        self.client.put(f"{BASE_URL}/{test_customer.id}/suspend")
+
+        response = self.client.get(f"{BASE_URL}/{test_customer.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "suspended")


### PR DESCRIPTION
## Description
Adds a `suspend` action endpoint to the Customer REST API, allowing a customer account to be suspended. Also introduces a `status` field to the `Customer` model to track account state.

## Changes

### Model (`service/models.py`)
- Added `status` field (`String(63)`, `NOT NULL`, default `"active"`)
- Updated `serialize()` to include `status`
- Updated `deserialize()` to read `status` (defaults to `"active"`)

### Routes (`service/routes.py`)
- Added `PUT /customers/<customer_id>/suspend` action endpoint
  - Returns `404` if customer not found
  - Sets `status = "suspended"`, persists, and returns updated customer with `200 OK`

### Tests (`tests/test_routes.py`)
- `test_suspend_a_customer` — asserts `200` and `status == "suspended"`
- `test_suspend_nonexistent_customer` — asserts `404` for missing customer
- `test_suspended_status_persists` — verifies status persists after a subsequent GET

### Factory (`tests/factories.py`)
- Added `status = "active"` default to `CustomerFactory`

## Testing
- All 39 tests pass
- Coverage: **96.92%**