### PR TITLE
Implement suspend/activate actions for Customer status (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ All endpoints are under the base path ```/customers ```
 | GET | ```/customers``` | Lists all the customers and their details |
 | GET | ```/customers/{id}``` | Retrieves a single customers details |
 | PUT | ```/customers/{id}``` | Updates a single customers details |
+| PUT | ```/customers/{id}/suspend``` | Sets customer status to ```suspended``` |
+| PUT | ```/customers/{id}/activate``` | Sets customer status to ```active``` |
 | DELETE | ```/customers/{id}``` | Deletes a single customers details |
    
 ## Contents

--- a/service/routes.py
+++ b/service/routes.py
@@ -168,6 +168,32 @@ def suspend_customer(customer_id):
 
 
 ######################################################################
+# ACTIVATE A CUSTOMER
+######################################################################
+@app.route("/customers/<int:customer_id>/activate", methods=["PUT"])
+def activate_customer(customer_id):
+    """
+    Activate a Customer
+
+    This endpoint will activate a Customer based on the id specified in the path
+    """
+    app.logger.info("Request to activate customer with id: %s", customer_id)
+
+    customer = Customer.find(customer_id)
+    if not customer:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Customer with id '{customer_id}' was not found.",
+        )
+
+    customer.status = "active"
+    customer.update()
+
+    app.logger.info("Customer with ID: %d activated.", customer.id)
+    return jsonify(customer.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 # UTILITY FUNCTIONS
 ######################################################################
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -290,3 +290,32 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.get_json()
         self.assertEqual(data["status"], "suspended")
+
+    def test_activate_a_customer(self):
+        """It should Activate a suspended Customer"""
+        test_customer = CustomerFactory(status="suspended")
+        test_customer.create()
+
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/activate")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "active")
+
+    def test_activate_nonexistent_customer(self):
+        """It should return 404 when activating a Customer that does not exist"""
+        response = self.client.put(f"{BASE_URL}/0/activate")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("was not found", data["message"])
+
+    def test_activated_status_persists(self):
+        """It should persist the active status after an activate call and GET"""
+        test_customer = CustomerFactory(status="suspended")
+        test_customer.create()
+
+        self.client.put(f"{BASE_URL}/{test_customer.id}/activate")
+
+        response = self.client.get(f"{BASE_URL}/{test_customer.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "active")


### PR DESCRIPTION
## Summary
This PR implements dedicated status actions for Customer accounts, including suspend and activate endpoints, and adds tests/documentation for the full workflow.

## Changes
- Added `PUT /customers/<id>/activate` endpoint
  - Sets `status` to `"active"`
  - Returns `200 OK` with updated customer payload
  - Returns `404 Not Found` when customer does not exist
- Kept and validated `PUT /customers/<id>/suspend`
  - Sets `status` to `"suspended"`
  - Returns `200 OK` with updated customer payload
  - Returns `404 Not Found` when customer does not exist
- Added route tests for activate scenarios:
  - successful activate
  - activate nonexistent customer (404)
  - status persistence after activate + GET
- Updated API reference in README to include:
  - `PUT /customers/{id}/suspend`
  - `PUT /customers/{id}/activate`

## Acceptance Criteria Coverage
- [x] `status` field present on Customer model/schema
- [x] suspend endpoint updates status to `suspended` and returns updated customer
- [x] 404 returned for nonexistent customer on status action endpoints
- [x] `serialize()` includes `status`
- [x] Unit tests cover suspend + activate success/nonexistent/persistence
- [x] Coverage remains >= 95% (verified in local sqlite run: 95.93%)

## Validation
Executed:
- `export DATABASE_URI=sqlite:////tmp/test.db && pytest -q tests/test_routes.py tests/test_models.py`

Result:
- `41 passed`
- `Total coverage: 95.93%`