### PR TITLE
Add bdd-test Tekton task to CD pipeline (#62)

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -12,6 +12,10 @@ spec:
       description: The reference (branch or ref)
       name: GIT_REF
       type: string
+    - default: ''
+      description: The external OpenShift route URL for the deployed microservice
+      name: BASE_URL
+      type: string
   tasks:
     - name: git-clone
       params:
@@ -70,6 +74,18 @@ spec:
         - git-clone
       taskRef:
         name: unit-test
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+    - name: bdd-tests
+      runAfter:
+        - tests
+        - lint
+      params:
+        - name: BASE_URL
+          value: $(params.BASE_URL)
+      taskRef:
+        name: bdd-test
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -68,3 +68,30 @@ spec:
         sys.exit(1)
         EOF
         pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: bdd-test
+spec:
+  params:
+    - name: BASE_URL
+      description: The external OpenShift route URL for the deployed microservice
+      type: string
+  workspaces:
+    - name: source
+  steps:
+    - name: run-bdd-tests
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: BASE_URL
+          value: $(params.BASE_URL)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        apt-get update && apt-get install -y --no-install-recommends \
+          chromium chromium-driver
+        pip install -U pip pipenv
+        pipenv install --system --dev
+        behave

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -33,6 +33,8 @@ spec:
                 secretKeyRef:
                   name: postgres-creds
                   key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
- Add bdd-test Task with BASE_URL param mapped to env variable
- Add BASE_URL parameter to cd-pipeline
- Add bdd-tests pipeline step that runs after lint and unit-test