### PR TITLE
add deploy task to CD pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -91,7 +91,7 @@ spec:
         - name: BASE_URL
           value: $(params.BASE_URL)
       runAfter:
-        - buildah
+        - deploy
       taskRef:
         kind: Task
         name: bdd-test
@@ -137,6 +137,29 @@ spec:
         resolver: cluster
       workspaces:
         - name: source
+          workspace: pipeline-workspace
+    - name: deploy
+      runAfter:
+        - buildah
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: openshift-client
+          - name: namespace
+            value: openshift-pipelines
+      params:
+        - name: SCRIPT
+          value: |
+            oc apply -f k8s/deployment.yaml
+            oc apply -f k8s/service.yaml
+            oc apply -f k8s/ingress.yaml
+            oc set image deployment/customers customers=$(params.IMAGE_NAME)
+            oc rollout status deployment/customers --timeout=300s
+      workspaces:
+        - name: manifest-dir
           workspace: pipeline-workspace
   workspaces:
     - name: pipeline-workspace


### PR DESCRIPTION
## Changes
- Added `deploy` task entry to `.tekton/pipeline.yaml` using the OpenShift `openshift-client` cluster resolver
- Deploy task applies `k8s/deployment.yaml`, `service.yaml`, `ingress.yaml` (skips `k8s/postgres/` per story acceptance criteria)
- Patches the deployment image to the freshly built `IMAGE_NAME` from buildah
- Waits for rollout completion via `oc rollout status`
- Updated `bdd-tests` to `runAfter: [deploy]` so BDD runs against the freshly deployed pods

Pipeline order is now: clone → [lint, tests in parallel] → buildah → deploy → bdd-tests.